### PR TITLE
update whitepaper.md - fix non-working chat link

### DIFF
--- a/WHITEPAPER.md
+++ b/WHITEPAPER.md
@@ -4,7 +4,7 @@
 Jae Kwon jae@tendermint.com<br/>
 Ethan Buchman ethan@tendermint.com
 
-For discussions, [join our Slack](http://forum.tendermint.com:3000/)!
+For discussions, [join our chat](https://riot.im/app/#/room/#cosmos:matrix.org)!
 
 _NOTE: If you can read this on GitHub, then we're still actively developing this
 document.  Please check regularly for updates!_


### PR DESCRIPTION
link to slack not working.  Link to riot chat room instead (since the cosmos.network home page provides the link to riot chat room)